### PR TITLE
chore: bump version 2026.7.3 -> 2026.8.0

### DIFF
--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [bumpver]
-current_version = "v2026.7.3"
+current_version = "v2026.8.0"
 version_pattern = "vYYYY.MM.INC0"
 commit_message = "chore: bump version {old_version_pep440} -> {new_version_pep440}"
 pre_commit_hook = ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gahojin-inc/holiday-japanese",
-  "version": "2026.7.3",
+  "version": "2026.8.0",
   "description": "Japanese holidays",
   "author": "GAHOJIN, Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * アプリケーションのバージョンを `2026.8.0` に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->